### PR TITLE
Fix Codecov

### DIFF
--- a/.github/workflows/CodeCoverage.yml
+++ b/.github/workflows/CodeCoverage.yml
@@ -87,3 +87,4 @@ jobs:
           name: ${{ runner.os }}-${{ matrix.compiler }}-${{ matrix.build_type }}
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
+          plugin: noop


### PR DESCRIPTION
For some reason the coverage just dropped by around 3% because it included function headers and other things which should not appear in a coverage report.
This change fixes that and moves the coverage back to what it was before.